### PR TITLE
Fix: Updated get_base_search_url to correctly apply user's experienceLevel preferences.

### DIFF
--- a/linkedIn_job_manager.py
+++ b/linkedIn_job_manager.py
@@ -176,7 +176,7 @@ class LinkedInJobManager:
         url_parts = []
         if parameters['remote']:
             url_parts.append("f_CF=f_WRA")
-        experience_levels = [str(i+1) for i, v in enumerate(parameters.get('experienceLevel', [])) if v]
+        experience_levels = [str(i+1) for i, (level, v) in enumerate(parameters.get('experienceLevel', {}).items()) if v]
         if experience_levels:
             url_parts.append(f"f_E={','.join(experience_levels)}")
         url_parts.append(f"distance={parameters['distance']}")


### PR DESCRIPTION
This PR fixes an issue in the get_base_search_url method where all experience levels were being included in the job search URL, regardless of user preferences.

This change:
1. Iterates through the 'experienceLevel' dictionary in the parameters
2. Only includes levels where the corresponding value is True
3. Correctly maps the index to LinkedIn's experience level values (1-6)

The job search URL will now accurately reflect the user's selected experience levels from the config.yaml file.