### PR TITLE
Fix import src module error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ generated_cv*
 .vscode
 chrome_profile
 answers.json
+virtual/
+data_folder/

--- a/run_cmd.sh
+++ b/run_cmd.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+resume_file=$1  # No spaces around the '=' sign
+
+# Add the src directory to PYTHONPATH
+export PYTHONPATH=$PYTHONPATH:$(pwd)/src
+
+# Run the Python script with the specified resume file
+if [ -z "$resume_file" ]; then  # Check if resume_file is empty
+    python main.py
+else
+    python main.py --resume "$resume_file"
+fi


### PR DESCRIPTION
In some environments, importing src directory modules raises errors. I've previously faced this issue as well. To tackle it, a good solution I found was to add the current working directory to PYTHONPATH env variable. Please provide additional optimal solutions, if any. Thanks!

**Improvements made:**
 - Added bash shell file to execute python 
 - Run `./run_cmd.sh` in terminal to execute the program
 - For passing custom resume, run `./run_cmd.sh "resume_file_path"` 
 - Added **data_source** folder into **.gitignore** to prevent committing secure data (like API keys) into Github
 - Added **virtual** folder into **.gitignore** to prevent committing dependencies from requirements.txt