### PR TITLE
Add configuration to apply once per job and once per company based on user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ This file defines your job search parameters and bot behavior. Each section cont
       - Italy
       - London
     ```
+- `applyOnceAtCompany: [True/False]`
+  - Set if you will apply in more than one opportunity per company
 
 - `distance: [number]`
   - Set the radius for your job search in miles

--- a/data_folder/config.yaml
+++ b/data_folder/config.yaml
@@ -31,6 +31,8 @@ locations:
   - Country1
   - Country2
 
+applyOnceAtCompany: [true/false]
+
 distance: 100
 
 companyBlacklist:

--- a/data_folder_example/config.yaml
+++ b/data_folder_example/config.yaml
@@ -26,9 +26,10 @@ date:
 positions:
   - Software Tester
 
-
 locations:
   - USA
+
+applyOnceAtCompany: [true/false]
 
 distance: 100
 


### PR DESCRIPTION
This pull request adds a new configuration option to control the job application process. The `applyOnceAtCompany` parameter allows users to specify whether they want to apply only once per company (`True` or `False`), preventing multiple applications to the same company. Additionally, a new feature ensures that users will not apply to the same job twice, based on the job link.

Changes include:
- Added `applyOnceAtCompany` option in the `config.yaml` file.
- Updated the `LinkedInJobManager` class to include logic that skips jobs where the user has already applied.
- Two new functions:
  1. `is_already_applied_to_job`: Checks if the user has already applied to the specific job.
  2. `is_already_applied_to_company`: Verifies if the user has already applied to a job at the same company, based on the `applyOnceAtCompany` setting.

These changes help streamline the application process, avoiding duplicate applications either at the job level or the company level.