### PR TITLE
Fix Section Name Parsing Issue in answer_question_textual_wide_range Method

### DIFF
--- a/src/gpt.py
+++ b/src/gpt.py
@@ -326,7 +326,11 @@ class GPTAnswerer:
         prompt = ChatPromptTemplate.from_template(section_prompt)
         chain = prompt | self.llm_cheap | StrOutputParser()
         output = chain.invoke({"question": question})
-        section_name = output.lower().replace(" ", "_")
+        match = re.search(r"(Personal information|Self Identification|Legal Authorization|Work Preferences|Education Details|Experience Details|Projects|Availability|Salary Expectations|Certifications|Languages|Interests|Cover letter)", output, re.IGNORECASE)
+        if not match:
+            raise ValueError("Could not extract section name from the response.")
+
+        section_name = match.group(1).lower().replace(" ", "_")
         if section_name == "cover_letter":
             chain = chains.get(section_name)
             output = chain.invoke({"resume": self.resume, "job_description": self.job_description})


### PR DESCRIPTION
There is an issue with how the bot processes the response from the answer_question_textual_wide_range method. The response is not being handled properly because it doesn't match the expected format for section names. The bot expects a simple string, such as "Personal Information," for the section name. However, the response (especially from the CosmosRP model) includes additional text and formatting that are not being stripped away.

To address this, a regular expression is implemented to match only the exact section names from the expected list. This ensures that any extraneous text is ignored and only the relevant section name is extracted. If no match is found, a ValueError is raised to flag any deviations in the response format.
![err1](https://github.com/user-attachments/assets/01fe7d61-cf51-4487-a676-b106bd07c9e8)
![err2](https://github.com/user-attachments/assets/9d565b79-da66-4979-9535-0a37afcb85de)
