### PR TITLE
use incognito mode to avoid linkedin auto login error

### DIFF
--- a/main.py
+++ b/main.py
@@ -153,6 +153,7 @@ class FileManager:
 def init_browser() -> webdriver.Chrome:
     try:
         options = chromeBrowserOptions()
+        options.add_argument("--incognito")  # Open Chrome in incognito mode
         service = ChromeService(ChromeDriverManager().install())
         return webdriver.Chrome(service=service, options=options)
     except Exception as e:


### PR DESCRIPTION
Without incognito mode:
![image](https://github.com/user-attachments/assets/333f47d4-4763-4834-8b1c-b4413bac14d3)
Linkedin automatically logs in and the bot throws an error because it can't find the Login form

With inconito mode the cookies are reset and LinkedIn doesn't automatically log in and the bot functions as expected