### PR TITLE
Ensure position is URL-encoded properly

### DIFF
--- a/src/linkedIn_job_manager.py
+++ b/src/linkedIn_job_manager.py
@@ -2,6 +2,7 @@ import os
 import random
 import time
 import traceback
+import urllib.parse
 from itertools import product
 from pathlib import Path
 from selenium.common.exceptions import NoSuchElementException
@@ -179,7 +180,8 @@ class LinkedInJobManager:
         return f"?{base_url}{date_param}"
     
     def next_job_page(self, position, location, job_page):
-        self.driver.get(f"https://www.linkedin.com/jobs/search/{self.base_search_url}&keywords={position}{location}&start={job_page * 25}")
+        encoded_position = urllib.parse.quote(position)
+        self.driver.get(f"https://www.linkedin.com/jobs/search/{self.base_search_url}&keywords={encoded_position}{location}&start={job_page * 25}")
     
     def extract_job_information_from_tile(self, job_tile):
         job_title, company, job_location, apply_method, link = "", "", "", "", ""


### PR DESCRIPTION
When position contained special characters, such as '#' :

`position = 'Software Engineer AND (".NET" OR C# OR "C Sharp") -Arquitect'`

The search text inserted in the URL was escaped to "Software Engineer AND (".NET" OR C" , getting fewer results than expected.