### PR TITLE
Fix: job title crawl issue

### DIFF
--- a/src/linkedIn_job_manager.py
+++ b/src/linkedIn_job_manager.py
@@ -184,7 +184,7 @@ class LinkedInJobManager:
     def extract_job_information_from_tile(self, job_tile):
         job_title, company, job_location, apply_method, link = "", "", "", "", ""
         try:
-            job_title = job_tile.find_element(By.CLASS_NAME, 'job-card-list__title').text
+            job_title = job_tile.find_element(By.CLASS_NAME, 'job-card-list__title').find_element(By.TAG_NAME, 'strong').text
             link = job_tile.find_element(By.CLASS_NAME, 'job-card-list__title').get_attribute('href').split('?')[0]
             company = job_tile.find_element(By.CLASS_NAME, 'job-card-container__primary-description').text
         except:


### PR DESCRIPTION
## Why
Origin Element will crawl the job title twice since LinkedIn has a hidden tag in this section.
![ScreenShot 2024-09-21 凌晨1 00 05](https://github.com/user-attachments/assets/63ef38b4-a0dc-40d4-bc09-01fc515211ce)
The result will be like blowing screenshot. (duplicate job tile )
![ScreenShot 2024-09-21 上午9 04 33](https://github.com/user-attachments/assets/14014b6a-3a5d-45cc-8700-51e0c7767091)

## How
only get the text value in `strong` tag




