### PR TITLE
Add Hugging API

### DIFF
--- a/data_folder/config.yaml
+++ b/data_folder/config.yaml
@@ -49,4 +49,7 @@ job_applicants_threshold:
   
 llm_model_type: openai
 llm_model: gpt-4o-mini 
+
+#llm_model_type: huggingface
+#llm_model: 'tiiuae/falcon-7b-instruct'
 # llm_api_url: https://api.pawan.krd/cosmosrp/v1 this field is optional

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ jsonschema==4.23.0
 jsonschema-specifications==2023.12.1
 langchain==0.2.11
 langchain-anthropic
+langchain-huggingface
 langchain-community==0.2.10
 langchain-core===0.2.36
 langchain-google-genai==1.0.10


### PR DESCRIPTION
Added Support for HuggingFace API and Model Handling, Updated Parsing Logic

-Introduced two new classes: HuggingFaceEndpoint (for API calls) and ChatHuggingFace (for model interaction)
-Adjusted the parse_llmresult method in the LoggerChatModel class because of the different response formats returned by ChatHuggingFace models compared to other proprietary models like ChatAnthropic or ChatOpenAI  (still requires further change )
-The specific model type and ID in use can be found in the config.yaml file